### PR TITLE
Workspaces should be ConfigurationScripts not ConfigurationScriptPayloads

### DIFF
--- a/app/models/manageiq/providers/terraform_enterprise/inventory/persister.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/inventory/persister.rb
@@ -2,9 +2,6 @@ class ManageIQ::Providers::TerraformEnterprise::Inventory::Persister < ManageIQ:
   def initialize_inventory_collections
     add_collection(automation, :configuration_scripts)
     add_collection(automation, :configuration_script_sources)
-    add_collection(automation, :configuration_script_payloads) do |builder|
-      builder.add_properties(:manager_ref => %i[manager_ref])
-      builder.add_default_values(:manager => manager)
-    end
+    add_collection(automation, :configuration_script_payloads)
   end
 end

--- a/spec/models/manageiq/providers/terraform_enterprise/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/terraform_enterprise/automation_manager/refresher_spec.rb
@@ -19,8 +19,8 @@ describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::Refresher 
 
     def assert_ems_counts
       expect(ems.configuration_script_sources.count).to eq(1)
-      expect(ems.configuration_script_payloads.count).to eq(2)
-      expect(ems.configuration_scripts.count).to eq(3)
+      expect(ems.configuration_script_payloads.count).to eq(1)
+      expect(ems.configuration_scripts.count).to eq(2)
     end
 
     def assert_specific_configuration_script_source
@@ -35,20 +35,20 @@ describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::Refresher 
     end
 
     def assert_specific_configuration_script_payload
-      configuration_script_payload = ems.configuration_script_payloads.find_by(:name => "terraform-test")
+      configuration_script_payload = ems.configuration_script_payloads.find_by(:manager_ref => "ws-BkpXRVrXTfUNXuxT")
       expect(configuration_script_payload).to have_attributes(
         :manager_ref                 => "ws-BkpXRVrXTfUNXuxT",
-        :name                        => "terraform-test",
+        :name                        => "agrare/terraform-test@master",
         :type                        => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::ConfigurationScriptPayload",
         :configuration_script_source => ems.configuration_script_sources.find_by(:name => "agrare/terraform-test")
       )
     end
 
     def assert_specific_configuration_script
-      configuration_script = ems.configuration_scripts.find_by(:manager_ref => "run-cRY3MuG7eHhBLRZd")
+      configuration_script = ems.configuration_scripts.find_by(:manager_ref => "ws-BkpXRVrXTfUNXuxT")
       expect(configuration_script).to have_attributes(
-        :manager_ref => "run-cRY3MuG7eHhBLRZd",
-        :parent      => ems.configuration_script_payloads.find_by(:name => "terraform-test"),
+        :manager_ref => "ws-BkpXRVrXTfUNXuxT",
+        :parent      => ems.configuration_script_payloads.find_by(:name => "agrare/terraform-test@master"),
         :type        => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::ConfigurationScript"
       )
     end


### PR DESCRIPTION
The Service Catalog UI code for ExternalAutomationManagers treats the `ConfigurationScript` aka Ansible Tower `JobTemplate` as the selectable item, the `ConfigurationScriptPayload` is strictly informational:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/catalog_controller.rb#L1642-L1647

The UI also uses `Configuration Jobs` aka `ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack` as an execution of a `ConfigurationScript`:
https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/controllers/configuration_job_controller.rb#L13 (NOTE AnsibleTower here is a bug and excludes AWX also)
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
