### PR TITLE
Add ProcessTasksMixin include to AutomationManager

### DIFF
--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::TerraformEnterprise::AutomationManager < ManageIQ::Providers::ExternalAutomationManager
+  include ProcessTasksMixin
+
   supports :create
 
   has_many :configuration_script_payloads, :foreign_key => :manager_id


### PR DESCRIPTION
Fix user-initiated refresh_ems from the UI failing on missing `process_tasks` method.  I'm not sure why this is handled different by the UI than a normal Infra/Cloud manager but this mixin is included in all ExternalAutomationManagers and ConfigurationManagers.

![Screenshot From 2025-05-08 12-16-26](https://github.com/user-attachments/assets/055a34b3-8b66-49dd-841a-2e884a42908f)

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
