### PR TITLE
Create a Run from a Terraform Enterprise Workspace

### DIFF
--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager.rb
@@ -4,6 +4,7 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager < ManageIQ::Pr
   supports :create
 
   has_many :configuration_script_payloads, :foreign_key => :manager_id
+  has_many :orchestration_stacks, :foreign_key => :ems_id
 
   def self.ems_type
     @ems_type ||= "terraform_enterprise".freeze

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script.rb
@@ -1,9 +1,40 @@
 class ManageIQ::Providers::TerraformEnterprise::AutomationManager::ConfigurationScript < ManageIQ::Providers::ExternalAutomationManager::ConfigurationScript
+  has_many :orchestration_stacks, :class_name => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack", :foreign_key => :configuration_script_id, :inverse_of => :configuration_script, :dependent => :nullify
+
   def self.display_name(number = 1)
-    n_('Run (%{provider_description})', 'Runs (%{provider_description})', number) % {:provider_description => module_parent.description}
+    n_('Workspace (Terraform Enterprise)', 'Workspaces (Terraform Enterprise)', number)
   end
 
   def self.stack_type
-    "Job"
+    "OrchestrationStack"
+  end
+
+  def run(options = {})
+    variables = options[:variables] || []
+
+    with_provider_connection do |tfe_client|
+      request_body = {
+        "data" => {
+          "attributes"    => {
+            "message"   => "Creating Run for Workspace name: [#{name}] manager_ref: [#{manager_ref}]",
+            "variables" => variables
+          },
+          "type"          => "runs",
+          "relationships" => {
+            "workspace" => {
+              "data" => {
+                "type" => "workspaces",
+                "id"   => manager_ref
+              }
+            }
+          }
+        }
+      }
+
+      response = tfe_client.post("runs", request_body.to_json)
+      raise response.reason_phrase unless response.success?
+
+      JSON.parse(response.body).dig("data", "id")
+    end
   end
 end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script_payload.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script_payload.rb
@@ -1,5 +1,7 @@
 class ManageIQ::Providers::TerraformEnterprise::AutomationManager::ConfigurationScriptPayload < ManageIQ::Providers::ExternalAutomationManager::ConfigurationScriptPayload
+  has_many :orchestration_stacks, :class_name => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack", :foreign_key => :configuration_script_base_id, :inverse_of => :configuration_script_payload, :dependent => :nullify
+
   def self.display_name(number = 1)
-    n_('Workspace (%{provider_description})', 'Workspaces (%{provider_description})', number) % {:provider_description => module_parent.description}
+    n_('Terraform Template (Terraform Enterprise)', 'Terraform Templates (Terraform Enterprise)', number)
   end
 end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
@@ -1,4 +1,6 @@
 class ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack < ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
+  include ProviderObjectMixin
+
   belongs_to :configuration_script,         :foreign_key => :configuration_script_id
   belongs_to :configuration_script_payload, :foreign_key => :configuration_script_base_id
 
@@ -32,5 +34,32 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Orchestration
 
   def raw_status
     Status.new(status)
+  end
+
+  def raw_stdout
+    with_provider_connection do |connection|
+      run     = provider_object(connection)
+      plan_id = run&.dig("relationships", "plan", "data", "id")
+      return if plan_id.nil?
+
+      response = connection.get("plans/#{plan_id}/json-output")
+      if response.status == 307 # HCP returns a HTTP 307 redirect for json-output
+        location = response.headers["location"]
+        response = connection.get(location)
+        return unless response.success?
+      end
+
+      JSON.parse(response.body)
+    end
+  end
+
+  def refresh_ems
+    ext_management_system.queue_refresh
+  end
+
+  def provider_object(connection = nil)
+    connection ||= ext_management_system.connect
+    response = connection.get("runs/#{ems_ref}")
+    JSON.parse(response.body)["data"] if response.success?
   end
 end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
@@ -1,0 +1,32 @@
+class ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack < ManageIQ::Providers::ExternalAutomationManager::OrchestrationStack
+  belongs_to :configuration_script,         :foreign_key => :configuration_script_id
+  belongs_to :configuration_script_payload, :foreign_key => :configuration_script_base_id
+
+  def self.display_name(number = 1)
+    n_('Run (Terraform Enterprise)', 'Runs (Terraform Enterprise)', number)
+  end
+
+  def self.create_stack(workspace, options = {})
+    run_id = raw_create_stack(workspace, options)
+
+    create!(
+      :name                         => workspace.name,
+      :ext_management_system        => workspace.manager,
+      :ems_ref                      => run_id,
+      :status                       => "pending",
+      :configuration_script         => workspace,
+      :configuration_script_payload => workspace.parent
+    )
+  end
+
+  def self.raw_create_stack(workspace, options = {})
+    workspace.run(options)
+  rescue => err
+    _log.error("Failed to create run from workspace [#{workspace.name}]: #{err}")
+    raise MiqException::MiqOrchestrationProvisionError, err.to_s, err.backtrace
+  end
+
+  def self.db_name
+    'ConfigurationJob'
+  end
+end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack.rb
@@ -29,4 +29,8 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Orchestration
   def self.db_name
     'ConfigurationJob'
   end
+
+  def raw_status
+    Status.new(status)
+  end
 end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
@@ -1,0 +1,52 @@
+class ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def initialize(status)
+    self.status = status
+    self.reason = self.class.run_state_to_description(status)
+  end
+
+  def succeeded?
+    status.downcase == "planned_and_finished"
+  end
+
+  def failed?
+    %w[policy_soft_failed errored].include?(status.downcase)
+  end
+
+  def canceled?
+    %w[discarded canceled force_canceled].include?(status.downcase)
+  end
+
+  # Lookup table of run state descriptions
+  # https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#run-states
+  def self.run_state_to_description(status)
+    case status
+    when "pending"              then N_("Pending")
+    when "fetching"             then N_("The run is waiting for HCP Terraform to fetch the configuration from VCS.")
+    when "fetching_complete"    then N_("HCP Terraform has fetched the configuration from VCS and the run will continue.")
+    when "pre_plan_running"     then N_("The pre-plan phase of the run is in progress.")
+    when "pre_plan_completed"   then N_("The pre-plan phase of the run has completed.")
+    when "queuing"              then N_("HCP Terraform is queuing the run to start the planning phase.")
+    when "plan_queued"          then N_("HCP Terraform is waiting for its backend services to start the plan.")
+    when "planning"             then N_("The planning phase of a run is in progress.")
+    when "planned"              then N_("The planning phase of a run has completed.")
+    when "cost_estimating"      then N_("The cost estimation phase of a run is in progress.")
+    when "cost_estimated"       then N_("The cost estimation phase of a run has completed.")
+    when "policy_checking"      then N_("The sentinel policy checking phase of a run is in progress.")
+    when "policy_override"      then N_("A sentinel policy has soft failed, and a user can override it to continue the run.")
+    when "policy_soft_failed"   then N_("A sentinel policy has soft failed for a plan-only run. This is a final state.")
+    when "policy_checked"       then N_("The sentinel policy checking phase of a run has completed.")
+    when "confirmed"            then N_("A user has confirmed the plan.")
+    when "post_plan_running"    then N_("The post-plan phase of the run is in progress.")
+    when "post_plan_completed"  then N_("The post-plan phase of the run has completed.")
+    when "planned_and_finished" then N_("The run is completed.  This is a final state.")
+    when "planned_and_saved"    then N_("The run has finished its planning, checks, and estimates, and can be confirmed for apply.")
+    when "apply_queued"         then N_("The run should start as soon as the backend services that run terraform have available capacity.")
+    when "applying"             then N_("Terraform is applying the changes specified in the plan.")
+    when "applied"              then N_("Terraform has applied the changes specified in the plan.")
+    when "discarded"            then N_("The run has been discarded. This is a final state.")
+    when "errored"              then N_("The run has errored. This is a final state.")
+    when "canceled"             then N_("The run has been canceled.")
+    when "force_canceled"       then N_("A workspace admin forcefully canceled the run.")
+    end
+  end
+end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
@@ -1,19 +1,19 @@
 class ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack::Status < ::OrchestrationStack::Status
   def initialize(status)
-    self.status = status
+    self.status = status.downcase
     self.reason = self.class.run_state_to_description(status)
   end
 
   def succeeded?
-    status.downcase == "planned_and_finished"
+    status == "planned_and_finished"
   end
 
   def failed?
-    %w[policy_soft_failed errored].include?(status.downcase)
+    %w[policy_soft_failed errored].include?(status)
   end
 
   def canceled?
-    %w[discarded canceled force_canceled].include?(status.downcase)
+    %w[discarded canceled force_canceled].include?(status)
   end
 
   # Lookup table of run state descriptions

--- a/app/models/manageiq/providers/terraform_enterprise/inventory/collector.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/inventory/collector.rb
@@ -15,6 +15,10 @@ class ManageIQ::Providers::TerraformEnterprise::Inventory::Collector < ManageIQ:
     @workspaces ||= orgs.flat_map { |org| paginated_get("organizations/#{org["id"]}/workspaces") }
   end
 
+  def workspaces_by_id
+    @workspaces_by_id ||= workspaces.index_by { |ws| ws["id"] }
+  end
+
   def runs
     @runs ||= workspaces.flat_map { |ws| paginated_get("workspaces/#{ws["id"]}/runs") }
   end

--- a/app/models/manageiq/providers/terraform_enterprise/inventory/parser.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/inventory/parser.rb
@@ -48,7 +48,15 @@ class ManageIQ::Providers::TerraformEnterprise::Inventory::Parser < ManageIQ::Pr
 
   def runs
     collector.runs.each do |run|
-      # TODO inventory runs as OrchestrationStacks
+      workspace_id = run.dig("relationships", "workspace", "data", "id")
+      workspace    = collector.workspaces_by_id[workspace_id]
+
+      persister.orchestration_stacks.build(
+        :ems_ref              => run["id"],
+        :name                 => workspace.dig("attributes", "name"),
+        :status               => run.dig("attributes", "status"),
+        :configuration_script => persister.configuration_scripts.lazy_find(workspace_id)
+      )
     end
   end
 end

--- a/app/models/manageiq/providers/terraform_enterprise/inventory/persister.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/inventory/persister.rb
@@ -3,5 +3,8 @@ class ManageIQ::Providers::TerraformEnterprise::Inventory::Persister < ManageIQ:
     add_collection(automation, :configuration_scripts)
     add_collection(automation, :configuration_script_sources)
     add_collection(automation, :configuration_script_payloads)
+    add_collection(automation, :orchestration_stacks) do |builder|
+      builder.default_values = {:ext_management_system => manager}
+    end
   end
 end

--- a/spec/factories/orchestration_stack.rb
+++ b/spec/factories/orchestration_stack.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :orchestration_stack_terraform_enterprise, :class => ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack
+end

--- a/spec/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack_spec.rb
@@ -1,9 +1,77 @@
 RSpec.describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack do
-  let(:stack) { FactoryBot.create(:orchestration_stack_terraform_enterprise, :ext_management_system => terraform_enterprise) }
+  let(:ems)    { FactoryBot.create(:ems_terraform_enterprise) }
+  let(:stack)  { FactoryBot.create(:orchestration_stack_terraform_enterprise, :ext_management_system => ems, :status => status) }
+  let(:status) { "pending" }
 
   describe "#raw_status" do
+    it "returns a Status object" do
+      expect(stack.raw_status).to be_kind_of(stack.class::Status)
+    end
+
+    describe "#reason" do
+      let(:status) { "canceled" }
+
+      it "returns a human friendly reason" do
+        expect(stack.raw_status.reason).to eq("The run has been canceled.")
+      end
+    end
+
+    describe "#succeeded?" do
+      it "returns falsey" do
+        expect(stack.raw_status.succeeded?).to be_falsey
+      end
+
+      context "with a successful status" do
+        let(:status) { "planned_and_finished" }
+
+        it "returns truthy" do
+          expect(stack.raw_status.succeeded?).to be_truthy
+        end
+      end
+    end
+
+    describe "#failed?" do
+      it "returns falsey" do
+        expect(stack.raw_status.failed?).to be_falsey
+      end
+
+      context "with a failed state" do
+        let(:status) { "errored" }
+
+        it "returns truthy" do
+          expect(stack.raw_status.failed?).to be_truthy
+        end
+      end
+    end
+
+    describe "#canceled?" do
+      it "returns falsey" do
+        expect(stack.raw_status.canceled?).to be_falsey
+      end
+
+      context "with a canceled state" do
+        let(:status) { "force_canceled" }
+
+        it "returns truthy" do
+          expect(stack.raw_status.canceled?).to be_truthy
+        end
+      end
+    end
   end
 
   describe "#refresh_ems" do
+    # Authentications are required for the queue_refresh to succeed
+    let(:ems) { FactoryBot.create(:ems_terraform_enterprise_with_vcr_authentication) }
+
+    it "queues a refresh of the orchestration_stack" do
+      stack.refresh_ems
+
+      expect(MiqQueue.count).to eq(1)
+      expect(MiqQueue.first).to have_attributes(
+        :class_name  => "EmsRefresh",
+        :method_name => "refresh",
+        :data        => [[ems.class.name, ems.id]]
+      )
+    end
   end
 end

--- a/spec/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::OrchestrationStack do
+  let(:stack) { FactoryBot.create(:orchestration_stack_terraform_enterprise, :ext_management_system => terraform_enterprise) }
+
+  describe "#raw_status" do
+  end
+
+  describe "#refresh_ems" do
+  end
+end

--- a/spec/models/manageiq/providers/terraform_enterprise/automation_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/terraform_enterprise/automation_manager/refresher_spec.rb
@@ -15,12 +15,14 @@ describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::Refresher 
       assert_specific_configuration_script_source
       assert_specific_configuration_script_payload
       assert_specific_configuration_script
+      assert_specific_orchestration_stack
     end
 
     def assert_ems_counts
       expect(ems.configuration_script_sources.count).to eq(1)
       expect(ems.configuration_script_payloads.count).to eq(1)
       expect(ems.configuration_scripts.count).to eq(2)
+      expect(ems.orchestration_stacks.count).to eq(3)
     end
 
     def assert_specific_configuration_script_source
@@ -50,6 +52,16 @@ describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::Refresher 
         :manager_ref => "ws-BkpXRVrXTfUNXuxT",
         :parent      => ems.configuration_script_payloads.find_by(:name => "agrare/terraform-test@master"),
         :type        => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::ConfigurationScript"
+      )
+    end
+
+    def assert_specific_orchestration_stack
+      orchestration_stack = ems.orchestration_stacks.find_by(:ems_ref => "run-dvL1cMGifahRqsYQ")
+      expect(orchestration_stack).to have_attributes(
+        :ems_ref => "run-dvL1cMGifahRqsYQ",
+        :name    => "test-workspace",
+        :status  => "planned_and_finished",
+        :configuration_script => ems.configuration_scripts.find_by(:name => "test-workspace")
       )
     end
   end


### PR DESCRIPTION
This creates a Run [[ref]](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run) from a TFE Workspace (`ConfigurationScript`) and an `OrchestrationStack` to keep track of the run.

Based off of AWX/AnsibleTower Job (their OrchestrationStack) https://github.com/ManageIQ/manageiq-providers-awx/blob/master/app/models/manageiq/providers/awx/automation_manager/job.rb#L20-L35
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
