### PR TITLE
Fix for TFE Run ending in Applied stuck service running

### DIFF
--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
@@ -5,7 +5,7 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Orchestration
   end
 
   def succeeded?
-    status == "planned_and_finished"
+    %w[planned_and_finished applied].include?(status)
   end
 
   def failed?


### PR DESCRIPTION
If a run finishes in "Applied" MIQ was keeping the OrchestrationStack status as running still
<img width="1189" height="400" alt="image" src="https://github.com/user-attachments/assets/5fa81880-fce9-4422-bb22-60c4ac5d3470" />

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
