### PR TITLE
MiqProvisionTask based provisioning

### DIFF
--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/configuration_script.rb
@@ -9,6 +9,10 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Configuration
     "OrchestrationStack"
   end
 
+  def my_zone
+    manager&.my_zone
+  end
+
   def run(options = {})
     variables = options[:variables] || []
 

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/orchestration_stack/status.rb
@@ -16,6 +16,10 @@ class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Orchestration
     %w[discarded canceled force_canceled].include?(status)
   end
 
+  def running?
+    !succeeded? && !failed? && !canceled?
+  end
+
   # Lookup table of run state descriptions
   # https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#run-states
   def self.run_state_to_description(status)

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/provision.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/provision.rb
@@ -1,0 +1,17 @@
+class ManageIQ::Providers::TerraformEnterprise::AutomationManager::Provision < MiqProvisionTask
+  include StateMachine
+
+  TASK_DESCRIPTION = N_("Terraform Enterprise Workspace Provision")
+
+  def self.request_class
+    MiqProvisionConfigurationScriptRequest
+  end
+
+  def my_role(*)
+    "ems_operations"
+  end
+
+  def my_queue_name
+    source.manager&.queue_name_for_ems_operations
+  end
+end

--- a/app/models/manageiq/providers/terraform_enterprise/automation_manager/provision/state_machine.rb
+++ b/app/models/manageiq/providers/terraform_enterprise/automation_manager/provision/state_machine.rb
@@ -1,0 +1,53 @@
+module ManageIQ::Providers::TerraformEnterprise::AutomationManager::Provision::StateMachine
+  def run_provision
+    signal :provision
+  end
+
+  def provision
+    stack_class = "#{source.class.module_parent}::#{source.class.stack_type}".constantize
+    stack       = stack_class.create_stack(source)
+
+    phase_context[:stack_id] = stack.id
+    save!
+
+    signal :check_provisioned
+  end
+
+  def check_provisioned
+    if running?
+      stack.refresh_ems
+      requeue_phase
+    else
+      signal :post_provision
+    end
+  end
+
+  def post_provision
+    if succeeded?
+      signal :mark_as_completed
+    else
+      abort_job("Failed to provision stack", "error")
+    end
+  end
+
+  def running?
+    stack.raw_status.running?
+  end
+
+  def succeeded?
+    stack.raw_status.succeeded?
+  end
+
+  def mark_as_completed
+    update_and_notify_parent(:state => 'provisioned')
+    signal :finish
+  end
+
+  def finish
+    mark_execution_servers
+  end
+
+  def stack
+    @stack ||= source.manager.orchestration_stacks.find(phase_context[:stack_id])
+  end
+end

--- a/spec/factories/miq_request_task.rb
+++ b/spec/factories/miq_request_task.rb
@@ -1,0 +1,3 @@
+FactoryBot.define do
+  factory :miq_provision_terraform_enterprise, :parent => :miq_provision, :class => "ManageIQ::Providers::TerraformEnterprise::AutomationManager::Provision"
+end

--- a/spec/models/manageiq/providers/terraform_enterprise/automation_manager/provision_spec.rb
+++ b/spec/models/manageiq/providers/terraform_enterprise/automation_manager/provision_spec.rb
@@ -1,0 +1,119 @@
+describe ManageIQ::Providers::TerraformEnterprise::AutomationManager::Provision do
+  let(:admin)        { FactoryBot.create(:user_admin) }
+  let(:zone)         { EvmSpecHelper.local_miq_server.zone }
+  let(:ems)          { FactoryBot.create(:ems_terraform_enterprise, :zone => zone).tap { |ems| ems.authentications << FactoryBot.create(:authentication, :status => "Valid", :auth_key => "abcd") } }
+  let(:workspace)    { FactoryBot.create(:configuration_script_terraform_enterprise, :manager => ems) }
+  let(:miq_request)  { FactoryBot.create(:miq_provision_request, :requester => admin, :source => workspace)}
+  let(:options)      { {:source => [workspace.id, workspace.name]} }
+  let(:new_stack)    { FactoryBot.create(:orchestration_stack_terraform_enterprise, :ext_management_system => ems, :status => stack_status) }
+  let(:stack_status) { "pending" }
+  let(:phase)        { nil }
+  let(:subject)     do
+    FactoryBot.create(
+      :miq_provision_terraform_enterprise,
+      :userid       => admin.userid,
+      :miq_request  => miq_request,
+      :source       => workspace,
+      :request_type => 'template',
+      :state        => 'pending',
+      :status       => 'Ok',
+      :options      => options,
+      :phase        => phase
+    )
+  end
+
+  it ".my_role" do
+    expect(subject.my_role).to eq("ems_operations")
+  end
+
+  it ".my_queue_name" do
+    expect(subject.my_queue_name).to eq(ems.queue_name_for_ems_operations)
+  end
+
+  describe ".run_provision" do
+    before do
+      allow(described_class.module_parent::OrchestrationStack).to receive(:create_stack).with(workspace).and_return(new_stack)
+    end
+
+    it "calls create_stack" do
+      expect(described_class.module_parent::OrchestrationStack).to receive(:create_stack)
+
+      subject.run_provision
+    end
+
+    it "sets stack_id" do
+      subject.run_provision
+
+      expect(subject.reload.phase_context).to include(:stack_id => new_stack.id)
+    end
+
+    it "queues check_provisioned" do
+      subject.run_provision
+
+      expect(subject.reload.phase).to eq("check_provisioned")
+      expect(MiqQueue.find_by(:class_name => "EmsRefresh", :method_name => "refresh"))
+        .to have_attributes(:state => "ready", :data => [[ems.class.name, ems.id]])
+    end
+
+    context "when create_stack fails" do
+      before do
+        expect(described_class.module_parent::OrchestrationStack).to receive(:create_stack).and_raise
+      end
+
+      it "marks the job as failed" do
+        subject.run_provision
+
+        expect(subject.reload).to have_attributes(:state => "finished", :status => "Error")
+      end
+    end
+  end
+
+  describe "check_provisioned" do
+    let(:phase) { "check_provisioned" }
+
+    context "when the plan is still running" do
+      let(:stack_status) { "planning" }
+
+      it "requeues check_provisioned" do
+        subject.phase_context[:stack_id] = new_stack.id
+        subject.check_provisioned
+
+        expect(subject.reload).to have_attributes(
+          :phase  => "check_provisioned",
+          :state  => "pending",
+          :status => "Ok"
+        )
+      end
+    end
+
+    context "when the plan is finished" do
+      let(:stack_status) { "planned_and_finished" }
+
+      it "finishes the job" do
+        subject.phase_context[:stack_id] = new_stack.id
+        subject.check_provisioned
+
+        expect(subject.reload).to have_attributes(
+          :phase  => "finish",
+          :state  => "provisioned",
+          :status => "Ok"
+        )
+      end
+    end
+
+    context "when the plan is errored" do
+      let(:stack_status) { "errored" }
+
+      it "finishes the job" do
+        subject.phase_context[:stack_id] = new_stack.id
+        subject.check_provisioned
+
+        expect(subject.reload).to have_attributes(
+          :phase  => "finish",
+          :state  => "finished",
+          :status => "Error"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extracted the MiqProvisionTask provision state machine out of https://github.com/ManageIQ/manageiq-providers-terraform_enterprise/pull/18 which has the `ProvisionWorkflow` as well which depends on core.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
